### PR TITLE
Fix spark-master to bind to last address from hostname -I by default

### DIFF
--- a/priv/extras_templates/spark/run.sh
+++ b/priv/extras_templates/spark/run.sh
@@ -9,7 +9,7 @@ if [ "$MASTER_URL" == "" ]; then
     HOST=${HOST:-0.0.0.0} #<< bind any
     if [[ "$HOST" == "" || "$HOST" == "0.0.0.0" ]]; then
         # reap bindable ips from ifconfig
-        HNA=($(ifconfig  | grep -E 'inet.[0-9]' | grep -v '127.0.0.1' | awk '{ print $2}'))
+        HNA=($(ifconfig |grep -E 'inet[^6]' |sed 's/addr://' |grep -v '127.0.0.1' |awk '{print $2}'))
         # take last address
         HNL=${#HNA[@]}
         HOST=${HNA[HNL-1]}


### PR DESCRIPTION
- fixed spark-master bind ip to use last address from `hostname -I` or SPARK_MASTER_IP likely set from /etc/profile.
