### PR TITLE
remove bashisms from spark scripts.

### DIFF
--- a/priv/extras_templates/spark/run.sh
+++ b/priv/extras_templates/spark/run.sh
@@ -1,18 +1,17 @@
-#! /bin/bash
+#! /bin/sh
 
 # ensure directory layout
 for i in logs work; do
       ! test -d $i && mkdir $i
 done
 
-if [ "$MASTER_URL" == "" ]; then
+if [ "$MASTER_URL" = "" ]; then
     HOST=${HOST:-0.0.0.0} #<< bind any
-    if [[ "$HOST" == "" || "$HOST" == "0.0.0.0" ]]; then
+    if [ "$HOST" = "" ] || [ "$HOST" = "0.0.0.0" ]; then
         # reap bindable ips from ifconfig
         HNA=($(ifconfig |grep -E 'inet[^6]' |sed 's/addr://' |grep -v '127.0.0.1' |awk '{print $2}'))
         # take last address
-        HNL=${#HNA[@]}
-        HOST=${HNA[HNL-1]}
+        for host in $HNA; do HOST=$host; done
     fi
     export HOST
     export RIAK_HOSTS=${RIAK_HOSTS:-"$HOST:8087"}

--- a/priv/extras_templates/spark/run.sh
+++ b/priv/extras_templates/spark/run.sh
@@ -9,7 +9,9 @@ if [ "$MASTER_URL" = "" ]; then
     HOST=${HOST:-0.0.0.0} #<< bind any
     if [ "$HOST" = "" ] || [ "$HOST" = "0.0.0.0" ]; then
         # reap bindable ips from ifconfig
-        HNA=($(ifconfig |grep -E 'inet[^6]' |sed 's/addr://' |grep -v '127.0.0.1' |awk '{print $2}'))
+        IFCONFIG=$(which ifconfig)
+        IFCONFIG=${IFCONFIG:-'/sbin/ifconfig'}
+        HNA=($($IFCONFIG |grep -E 'inet[^6]' |sed 's/addr://' |grep -v '127.0.0.1' |awk '{print $2}'))
         # take last address
         for host in $HNA; do HOST=$host; done
     fi

--- a/priv/extras_templates/spark/stop.sh
+++ b/priv/extras_templates/spark/stop.sh
@@ -1,4 +1,5 @@
-if [ "$MASTER_URL" == "" ]; then
+#! /bin/sh
+if [ "$MASTER_URL" = "" ]; then
     ./sbin/stop-slave.sh
 else
     ./sbin/stop-master.sh


### PR DESCRIPTION
- Removed bashisms from spark scripts
- tested with checkbashisms
- ensured ifconfig is found, whether it is in PATH or not.
