### PR TITLE
Add --output-port flag to start-service command

### DIFF
--- a/src/data_platform_console.erl
+++ b/src/data_platform_console.erl
@@ -503,10 +503,13 @@ remove_service_config_usage() ->
 
 start_service_usage() ->
     [
-     "data-platform-admin start-service <node> <group> <service> [-i | --output-ip]\n",
+     "data-platform-admin start-service <node> <group> <service>\n",
+     "                     [-i | --output-ip] [-p | --output-port]\n",
      " Start a service on an the designated platform instance\n\n",
      " The -i/--output-ip flag will cause the IP address of <node>\n",
-     " to be printed back out on the console in lieu of the normal output.\n"
+     " to be printed back out on the console in lieu of the normal output.\n\n",
+     " The -p/--output-port flag will similarly cause the configured port\n",
+     " of the service to be printed out on the console.\n"
     ].
 
 stop_service_usage() ->


### PR DESCRIPTION
The new --output-port flag (or -p for short) causes the service's port to be printed out as a result of the start-service command. This can be specified on its own, or combined with the --output-ip flag to print both the IP and the port of the service. In the case of both flags being specified, the two values are printed on separate lines to facilitate easy parsing for scripting purposes.
