### PR TITLE
Bump Clique to version 0.3.5

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 {cover_enabled, true}.
 {xref_checks, [undefined_function_calls]}.
 {deps, [{lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
-        {clique, "0.3.2", {git, "git://github.com/basho/clique.git", {tag, "0.3.1"}}},
+        {clique, "0.3.5", {git, "git://github.com/basho/clique.git", {tag, "0.3.5"}}},
         {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}},
         {exec, ".*", {git, "https://github.com/saleyn/erlexec.git"}},
         {plumtree, ".*", {git, "git://github.com/basho/plumtree.git"}},

--- a/rebar.config
+++ b/rebar.config
@@ -7,9 +7,9 @@
              {dir, "edoc"}]}.
 {cover_enabled, true}.
 {xref_checks, [undefined_function_calls]}.
-{deps, [{lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
-        {clique, "0.3.5", {git, "git://github.com/basho/clique.git", {tag, "0.3.5"}}},
+{deps, [{lager, "2.*", {git, "git://github.com/basho/lager.git", {branch, "2.x"}}},
+        {clique, "0.3.*", {git, "git://github.com/basho/clique.git", {tag, "0.3.5"}}},
         {ranch, "0.4.0-p1", {git, "git://github.com/basho/ranch.git", {tag, "0.4.0-p1"}}},
         {exec, ".*", {git, "https://github.com/saleyn/erlexec.git"}},
-        {plumtree, ".*", {git, "git://github.com/basho/plumtree.git"}},
-        {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble"}}]}.
+        {plumtree, ".*", {git, "git://github.com/basho/plumtree.git", {branch, "develop"}}},
+        {riak_ensemble, ".*", {git, "git://github.com/basho/riak_ensemble", {tag, "2.1.2"}}}]}.


### PR DESCRIPTION
- bumped clique to 0.3.5 as it now pins cuttlefish properly at a tag.

Version 0.3.4 allows us to return custom exit status codes for commands.

There is currently a PR outstanding that uses these new features to add useful exit codes to the data-platform-admin utility, but this must be merged first.
